### PR TITLE
Regex matches to hostname rather than address

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -277,7 +277,7 @@ func main() {
 
 		var hosts []*sup.Host
 		for _, host := range network.Hosts {
-			if expr.MatchString(host.Address) {
+			if expr.MatchString(host.GetHostname()) {
 				hosts = append(hosts, host)
 			}
 		}
@@ -298,7 +298,7 @@ func main() {
 
 		var hosts []*sup.Host
 		for _, host := range network.Hosts {
-			if !expr.MatchString(host.Address) {
+			if !expr.MatchString(host.GetHostname()) {
 				hosts = append(hosts, host)
 			}
 		}


### PR DESCRIPTION
Should it match to GetHostname instead?