### PR TITLE
Use = to match exact string with only/except flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Stack Up is a simple deployment tool that performs given set of commands on mult
 |-------------------|----------------------------------|
 | `-f Supfile`      | Custom path to Supfile           |
 | `-e`, `--env=[]`  | Set environment variables        |
-| `-only REGEXP`    | Filter hosts matching regexp     |
-| `-except REGEXP`  | Filter out hosts matching regexp |
+| `-only REGEXP`    | Filter hosts matching regexp (use =HOSTNAME for exact match) |
+| `-except REGEXP`  | Filter out hosts matching regexp (use =HOSTNAME for exact match) |
 | `-debug`, `-D`    | Enable debug/verbose mode        |
 | `-disable-prefix` | Disable hostname prefix          |
 | `-help`, `-h`     | Show help/usage                  |

--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -269,20 +269,29 @@ func main() {
 
 	// --only flag filters hosts
 	if onlyHosts != "" {
-		expr, err := regexp.CompilePOSIX(onlyHosts)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-
 		var hosts []*sup.Host
-		for _, host := range network.Hosts {
-			if expr.MatchString(host.GetHostname()) {
-				hosts = append(hosts, host)
+		if strings.HasPrefix(onlyHosts, "=") {
+			exactMatch := onlyHosts[1:] // Remove the = prefix
+			for _, host := range network.Hosts {
+				if host.GetHostname() == exactMatch {
+					hosts = append(hosts, host)
+					break
+				}
+			}
+		} else {
+			expr, err := regexp.CompilePOSIX(onlyHosts)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			for _, host := range network.Hosts {
+				if expr.MatchString(host.GetHostname()) {
+					hosts = append(hosts, host)
+				}
 			}
 		}
 		if len(hosts) == 0 {
-			fmt.Fprintln(os.Stderr, fmt.Errorf("no hosts match --only '%v' regexp", onlyHosts))
+			fmt.Fprintln(os.Stderr, fmt.Errorf("no hosts match --only '%v'", onlyHosts))
 			os.Exit(1)
 		}
 		network.Hosts = hosts
@@ -290,20 +299,28 @@ func main() {
 
 	// --except flag filters out hosts
 	if exceptHosts != "" {
-		expr, err := regexp.CompilePOSIX(exceptHosts)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-
 		var hosts []*sup.Host
-		for _, host := range network.Hosts {
-			if !expr.MatchString(host.GetHostname()) {
-				hosts = append(hosts, host)
+		if strings.HasPrefix(exceptHosts, "=") {
+			exactMatch := exceptHosts[1:] // Remove the = prefix
+			for _, host := range network.Hosts {
+				if host.GetHostname() != exactMatch {
+					hosts = append(hosts, host)
+				}
+			}
+		} else {
+			expr, err := regexp.CompilePOSIX(exceptHosts)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			for _, host := range network.Hosts {
+				if !expr.MatchString(host.GetHostname()) {
+					hosts = append(hosts, host)
+				}
 			}
 		}
 		if len(hosts) == 0 {
-			fmt.Fprintln(os.Stderr, fmt.Errorf("no hosts left after --except '%v' regexp", onlyHosts))
+			fmt.Fprintln(os.Stderr, fmt.Errorf("no hosts left after --except '%v' regexp", exceptHosts))
 			os.Exit(1)
 		}
 		network.Hosts = hosts


### PR DESCRIPTION
After changing to GetHostname, now there is no real way to explicitly specify a single node.